### PR TITLE
feat(parser): Support assignment of 'None' values for standalone query-string keys

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -156,6 +156,7 @@ pub fn merge(to: &mut Value, from: &Value) -> Option<Value> {
     match to {
         &mut Value::Object(_) => {
             match from {
+                &Value::Null => None,
                 &Value::Array(_) => merge_object_and_array(to, from),
                 &Value::Object(_) if is_merger(from) => merge_object_and_merger(to, from),
                 &Value::Object(_) => merge_object_and_object(to, from),
@@ -165,6 +166,7 @@ pub fn merge(to: &mut Value, from: &Value) -> Option<Value> {
         }
         &mut Value::Array(_) => {
             match from {
+                &Value::Null => None,
                 &Value::Array(_) => merge_list_and_list(to, from),
                 &Value::Object(_) if is_merger(from) => merge_list_and_merger(to, from),
                 &Value::Object(_) => merge_list_and_object(to, from),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -34,25 +34,25 @@ pub fn decode_component(source: &str) -> Result<String,String> {
     return Ok(result);
 }
 
-fn parse_pairs(body: &str) -> Vec<(&str, Option<&str>)> {
-
-    let mut pairs = vec![];
-
-    for part in body.split("&") {
-        let separator = part.find("]=")
-                            .and_then(|pos| Some(pos+1))
-                            .or_else(|| part.find("="));
-
-        match separator {
-            None => pairs.push((part, None)),
-            Some(pos) => {
-                let key = &part[..pos];
-                let val = &part[(pos + 1)..];
-                pairs.push((key, Some(val)));
-            }
+fn parse_pair(part: &str) -> (&str, Option<&str>) {
+    let separator = part.find("]=")
+                        .and_then(|pos| Some(pos+1))
+                        .or_else(|| part.find("="));
+    match separator {
+        None => return (part, None),
+        Some(pos) => {
+            let key = &part[..pos];
+            let val = &part[(pos + 1)..];
+            return (key, Some(val));
         }
     }
+}
 
+fn parse_pairs(body: &str) -> Vec<(&str, Option<&str>)> {
+    let mut pairs = vec![];
+    for part in body.split("&") {
+        pairs.push(parse_pair(part));
+    }
     return pairs
 }
 
@@ -192,10 +192,16 @@ pub fn parse(params: &str) -> ParseResult<Value> {
 #[cfg(test)]
 mod tests {
     use parse;
+    use super::parse_pair;
     use serde_json::{Value, to_string};
 
     fn eq_str(value: Value, string: &str) {
         assert_eq!(&to_string(&value).unwrap(), string)
+    }
+
+    #[test]
+    fn test_parse_pair() {
+        assert_eq!(parse_pair("foo=1"), ("foo", Some("1")));
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -245,6 +245,12 @@ mod tests {
     }
 
     #[test]
+    fn it_transforms_standalone_keys() {
+        eq_str(parse("foo=bar&baz").unwrap(),
+            r#"{"foo":"bar","baz":null}"#);
+    }
+
+    #[test]
     fn it_doesnt_produce_empty_keys() {
         eq_str(parse("_r=1&").unwrap(),
             r#"{"_r":"1"}"#);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -202,6 +202,8 @@ mod tests {
     #[test]
     fn test_parse_pair() {
         assert_eq!(parse_pair("foo=1"), ("foo", Some("1")));
+        assert_eq!(parse_pair("empty="), ("empty", Some("")));
+        assert_eq!(parse_pair("noval"), ("noval", None));
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -179,7 +179,7 @@ pub fn parse(params: &str) -> ParseResult<Value> {
         let parse_key_res = try!(parse_key(key));
         let key_chain = &parse_key_res[0..];
         let decoded_value = match value {
-            None => Value::Null,
+            None => Value::default(),
             Some(val) => match decode_component(val) {
                 Ok(decoded_value) => Value::String(decoded_value),
                 Err(err) => return Err(ParseError{ kind: ParseErrorKind::DecodingError, message: err })


### PR DESCRIPTION
In a number of query-string parsing and serialization environments there is ambiguity about the intent and meaning of `?a=` vs `?a`.

The [URI RFC](https://tools.ietf.org/html/rfc3986) allows for both inside URIs, and does not specify behaviour.  Many environments choose to have both null/none/empty and also empty-string values serialize to `a=`.

This can lead to ambiguity and in some cases it could be useful to reliably parse null/none/empty values back from a query-string (`a`), while retaining the ability to parse empty strings (`a=`).

This pull request is a work-in-progress; I'd like to resolve the following:

- [ ] Backwards-compatibility: ideally the existing behaviour should be maintained for prior library versions; in other words, unless requested otherwise, a `None` match for a value should return an empty string unless the caller opts-in for `None` result value parsing