### PR TITLE
Also accept semicolon as pair delimiter, behind feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ rust = "1.13"
 [features]
 default = ["regex1"]
 regex1 = ["regex", "lazy_static"]
+semicolon-delimiters = []
 
 [dependencies]
 serde = "^1"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -50,6 +50,11 @@ fn parse_pair(part: &str) -> (&str, Option<&str>) {
 
 fn parse_pairs(body: &str) -> Vec<(&str, Option<&str>)> {
     let mut pairs = vec![];
+    #[cfg(feature = "semicolon-delimiters")]
+    for part in body.split(|c| c == '&' || c == ';') {
+        pairs.push(parse_pair(part));
+    }
+    #[cfg(not(feature = "semicolon-delimiters"))]
     for part in body.split("&") {
         pairs.push(parse_pair(part));
     }


### PR DESCRIPTION
I am trying to (ab)use this library to parse attributes in the path component of PKCS11 URIs (RFC 7512), which use semicolon delimiters (in the query component, the usual ampersand delimiters are used). I honestly don't know where this comes from, maybe the obsolete RFC 1866 which mentions accepting both semicolons and ampersands.

What do you think about this? I'd completely understand if you think such a feature is out of scope.

